### PR TITLE
feat: Add functionality (and tests) to create a deck

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -16,7 +16,24 @@ function evaluateGuess(guess, correctAnswer) {
   }
 }
 
+function createDeck() {
+  let deck = [];
+  return deck;
+}
+
+function addCardToDeck(deck, card) {
+  deck.push(card);
+}
+
+function countCards(deck) {
+  let cardCount = deck.length;
+  return cardCount;
+}
+
 module.exports = {
   createCard,
-  evaluateGuess
+  evaluateGuess,
+  createDeck,
+  addCardToDeck,
+  countCards
 }

--- a/test/Card-test.js
+++ b/test/Card-test.js
@@ -1,7 +1,7 @@
 const chai = require('chai');
 const expect = chai.expect;
 
-const { createCard, evaluateGuess } = require('../src/card');
+const { createCard, evaluateGuess, createDeck, addCardToDeck, countCards } = require('../src/card');
 
 describe('cards', function() {
   describe('card creation', function() {
@@ -34,6 +34,80 @@ describe('cards', function() {
       const card = createCard(2, 'What is Robbie\'s favorite animal', ['sea otter', 'pug', 'capybara'], 'sea otter');
       const guess = 'sea otter';
       expect(evaluateGuess(guess, card.correctAnswer)).to.deep.equal('correct!');
+    });
+  });
+
+  describe('deck creation', function() {
+    it('should create an empty deck', function() {
+      const deck = createDeck();
+      expect(deck).to.deep.equal([]);
+    });
+
+    it('should add cards to a deck', function() {
+      const card1 = createCard(1, 'What is Robbie\'s favorite animal', ['sea otter', 'pug', 'capybara'], 'sea otter');
+      const card2 = createCard(14, 'What organ is Khalid missing?', ['spleen', 'appendix', 'gallbladder'], 'gallbladder');
+      const card3 = createCard(12, 'What is Travis\'s middle name?', ['Lex', 'William', 'Fitzgerald'], 'Fitzgerald');
+
+      const deck = createDeck();
+
+      addCardToDeck(deck, card1);
+      expect(deck).to.deep.equal([{
+        id: 1,
+        question: "What is Robbie's favorite animal",
+        answers: [ 'sea otter', 'pug', 'capybara' ],
+        correctAnswer: 'sea otter'
+      }]);
+
+      addCardToDeck(deck, card2);
+      expect(deck).to.deep.equal([{
+        id: 1,
+        question: "What is Robbie's favorite animal",
+        answers: [ 'sea otter', 'pug', 'capybara' ],
+        correctAnswer: 'sea otter'
+      },
+      {
+        id: 14,
+        question: 'What organ is Khalid missing?',
+        answers: [ 'spleen', 'appendix', 'gallbladder' ],
+        correctAnswer: 'gallbladder'
+      }]);
+      addCardToDeck(deck, card3);
+
+      expect(deck).to.deep.equal([{
+        id: 1,
+        question: "What is Robbie's favorite animal",
+        answers: [ 'sea otter', 'pug', 'capybara' ],
+        correctAnswer: 'sea otter'
+      },
+      {
+        id: 14,
+        question: 'What organ is Khalid missing?',
+        answers: [ 'spleen', 'appendix', 'gallbladder' ],
+        correctAnswer: 'gallbladder'
+      },
+      {
+        id: 12,
+        question: "What is Travis's middle name?",
+        answers: [ 'Lex', 'William', 'Fitzgerald' ],
+        correctAnswer: 'Fitzgerald'
+      }]);
+    });
+
+    it('should know how many cards are in the deck', function() {
+      const card1 = createCard(1, 'What is Robbie\'s favorite animal', ['sea otter', 'pug', 'capybara'], 'sea otter');
+      const card2 = createCard(14, 'What organ is Khalid missing?', ['spleen', 'appendix', 'gallbladder'], 'gallbladder');
+      const card3 = createCard(12, 'What is Travis\'s middle name?', ['Lex', 'William', 'Fitzgerald'], 'Fitzgerald');
+
+      const deck = createDeck();
+
+      addCardToDeck(deck, card1);
+      expect(countCards(deck)).to.deep.equal(1);
+
+      addCardToDeck(deck, card2);
+      expect(countCards(deck)).to.deep.equal(2);
+
+      addCardToDeck(deck, card3);
+      expect(countCards(deck)).to.deep.equal(3);
     });
   });
 });


### PR DESCRIPTION
# Description
- Add `createDeck` function to `card.js`
  - creates an empty deck
- Add `addCardToDeck` function to `card.js`
  - adds cards to an existing deck
- Add `countCards` function to `card.js`
  - counts the number of cards in a given deck
- Add tests for all three functions to `Card-test.js`